### PR TITLE
Fix: Path handling, file not found errors, and Windows compatibility

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,21 +9,17 @@
 ### Run:
 * Navigate to source dir in console and type: `python xting.py` in console to run the application
 * or directly click `xting.py` to run
+* another way would be to install the executable from the releases tag
 
 ### Authors:
 * sanfanling (xujia19@outlook.com) (the original author)
-* putridambassador121 (the maintainer of the fork)
+* putridambassador121 (the maintainer of this fork)
 
 ### Note:
-* Originally developed in the Linux environment, but could run in windows system theoretically, never tested, welcome report.
+* Originally developed in the Linux environment by the original author, now it runs on Windows 10 and is being developed by me there.
 
 ### Next todo list:
-* [x] finish all lrcShow-X context menu function
-* [x] finish album cover function
-* [x] finish play list function
-* [x] finish shortcuts function
-* [x] add shortcuts config page
-* [x] finish lrc edit function
-* [x] icons
-* [x] edit track tags
-* [] bug fix
+* [x] make it search for cover art on the file itself (as of this version, only mp3 and flac are supported for this functionality, more are planned)
+* [] make it search for cover art online if the cover is not available on the file
+* [] add a sound driver watcher on the gui (make it detect automatically if a sound device like a headphone got disconnected, without needing to restart the app just to use it)
+

--- a/README.md
+++ b/README.md
@@ -10,11 +10,12 @@
 * Navigate to source dir in console and type: `python xting.py` in console to run the application
 * or directly click `xting.py` to run
 
-### Author:
-* sanfanling (xujia19@outlook.com)
+### Authors:
+* sanfanling (xujia19@outlook.com) (the original author)
+* putridambassador121 (the maintainer of the fork)
 
 ### Note:
-* Developed in Linux environment, but could run in windows system theoretically, never tested, welcome report.
+* Originally developed in the Linux environment, but could run in windows system theoretically, never tested, welcome report.
 
 ### Next todo list:
 * [x] finish all lrcShow-X context menu function

--- a/dockWidgets.py
+++ b/dockWidgets.py
@@ -12,7 +12,9 @@ from lrcShowX.lrcShowX import lrcShowX
 from mutagen.flac import FLAC, Picture
 from mutagen.mp3 import MP3
 from mutagen.id3 import ID3, APIC, error
+from pathlib import Path
 
+basedir = Path(__file__).resolve().parent.as_posix()
 
 class lrcShowxDock(QDockWidget):
 
@@ -235,7 +237,7 @@ class albumCoverWidget(QLabel):
             pass
 
     def setBlankCover(self):
-        pix = QPixmap("icon/blankAlbum.png").scaled(270, 270)
+        pix = QPixmap(os.path.join(basedir, "icon/blankAlbum.png")).scaled(270, 270)
         self.setPixmap(pix)
 
     def searchMedia(self):

--- a/dockWidgets.py
+++ b/dockWidgets.py
@@ -5,9 +5,48 @@
 
 import os, sys, re
 from track import track
-from PyQt6.QtWidgets import *
-from PyQt6.QtCore import *
-from PyQt6.QtGui import *
+
+from PyQt6.QtCore import (
+    QUrl,
+    Qt,
+    QVariant,
+    QDir
+)
+from PyQt6.QtWidgets import (
+    QApplication,
+    QFileDialog,
+    QMessageBox,
+    QMenuBar,
+    QFileDialog,
+    QWidget,
+    QVBoxLayout,
+    QPlainTextEdit,
+    QDockWidget,
+    QToolBar,
+    QLabel,
+    QHBoxLayout,
+    QLineEdit,
+    QAbstractItemView,
+    QTableView,
+    QListView,
+    QMenu,
+    QInputDialog
+)
+
+
+from PyQt6.QtGui import (
+    QIcon,
+    QKeySequence,
+    QPixmap,
+    QAction,
+    QTextCursor,
+    QStandardItemModel,
+    QStandardItem,
+    QFileSystemModel
+)
+# from PyQt6.QtWidgets import *
+# from PyQt6.QtCore import *
+# from PyQt6.QtGui import *
 from lrcShowX.lrcShowX import lrcShowX
 from mutagen.flac import FLAC, Picture
 from mutagen.mp3 import MP3
@@ -242,15 +281,27 @@ class albumCoverWidget(QLabel):
 
     def searchMedia(self):
         f = self.parent.parent.currentTrack.trackFile
-        audio = FLAC(f)
-        if audio.pictures:
-            p = audio.pictures[0]
-            pix = QPixmap()
-            pix.loadFromData(p.data)
-            pix = pix.scaled(270, 270)
-            self.setPixmap(pix)
-        else:
-            self.searchOnline()
+        
+        if Path(f).suffix.lower() == ".mp3":
+            audio = MP3(f, ID3=ID3)
+            for tag in audio.tags.values():
+                if isinstance(tag, APIC) and tag.type == 3:
+                    pix = QPixmap()
+                    pix.loadFromData(tag.data)
+                    pix = pix.scaled(270, 270)
+                    self.setPixmap(pix)
+                else:
+                    self.searchOnline()
+        elif Path(f).suffix.lower() == ".flac":  
+            audio = FLAC(f)
+            if audio.pictures:
+                p = audio.pictures[0]
+                pix = QPixmap()
+                pix.loadFromData(p.data)
+                pix = pix.scaled(270, 270)
+                self.setPixmap(pix)
+            else:
+                self.searchOnline()
 
     def searchOnline(self):
         pass
@@ -448,7 +499,7 @@ class playlistWidget(QWidget):
     def savePlaylistAction_(self):
         if self.parent.parent.parameter.currentPlaylistName:
             t = "\n".join(self.parent.parent.playlistTmp) + "\n"
-            with open(self.parent.parent.parameter.currentPlaylistName, "w") as f:
+            with open(self.parent.parent.parameter.currentPlaylistName, "w", encoding="utf-8") as f:
                 f.write(t)
         else:
             self.saveasPlayListAction_()

--- a/lrcShowX/lrcParser.py
+++ b/lrcShowX/lrcParser.py
@@ -4,6 +4,8 @@
 
 
 import os, re
+import html
+from pathlib import Path
 
 class lrcParser:
 
@@ -21,11 +23,12 @@ class lrcParser:
 
     def parse(self):
         if not self.isFile:
-            lineList = self.lrcfile.split("\n")
+            lineList = self.lrcfile.replace("\\n", "\n").split("\n")
         else:
-            with open(self.lrcfile, "r") as f:
+            with open(self.lrcfile, "r", encoding="utf-8") as f:
                 lineList = f.readlines()
-        lineList = list(map(lambda x: x.strip().replace("<br />", ""), lineList))
+        
+        lineList = list(map(lambda x: html.unescape(x.strip().replace("<br />", "")), lineList))
         self.syncedLyrics.lrcWithTag = "\n".join(lineList)
 
         offset = 0
@@ -82,7 +85,12 @@ class syncedLyrics:
         self.offset = 0
 
 if __name__ == "__main__":
-    p = lrcParser("b.lrc")
+    base_dir = base_dir = Path(__file__).resolve().parent.as_posix()
+    lrc = Path(Path(base_dir) / "b.lrc").as_posix()
+    
+    # p = lrcParser("b.lrc")
+    p = lrcParser(lrc)
     l = p.parse()
     print(l)
-    print(l[2][1])
+    print(l.lrcFrom)
+    # print(l[2][1])

--- a/lrcShowX/lrcShowX.py
+++ b/lrcShowX/lrcShowX.py
@@ -137,6 +137,7 @@ class lrcShowX(QTextBrowser):
 
                 p = lrcParser(fi, True)
                 self.lrcInstance = p.parse()
+                # print(self.lrcInstance.lrcWithTag)
                 self.showLrc()
                 self.forwardAction.setEnabled(True)
                 self.backwardAction.setEnabled(True)
@@ -402,6 +403,7 @@ class lrcShowX(QTextBrowser):
 
     def showLrc(self):
         l = self.formartLrc()
+        # print(l)
         self.setHtml(l)
         self.setAlignment(Qt.AlignmentFlag.AlignCenter)
 
@@ -420,6 +422,7 @@ class lrcShowX(QTextBrowser):
 
                 context += t
             co = nullLines + context + 50 * j + '<p align="center">&nbsp;</p>'
+            # print(co)
             return co
 
     def initFont(self):

--- a/lrcShowX/lrclibThread.py
+++ b/lrcShowX/lrclibThread.py
@@ -1,6 +1,10 @@
 #! /usr/bin/python
 
-from PyQt6.QtCore import *
+from PyQt6.QtCore import (
+    pyqtSignal,
+    QThread,
+    QThreadPool
+)
 
 
 
@@ -13,16 +17,20 @@ class lrclibSearchThread(QThread):
         self.api = api
         self.title = title
         self.artist = artist
+        self.threadpool = QThreadPool()
     
+
     def run(self):
         r = []
         results = self.api.search_lyrics(self.title, self.artist)
-        for i in results:
-            if i.instrumental:
-                continue
-            else:
-                r.append(i)
-        self.lrcSearched.emit(r)
+        if results is not None or len(results) == 0:
+            for i in results:
+                if i.instrumental:
+                    continue
+                else:
+                    r.append(i)
+            self.lrcSearched.emit(r)
+
 
 class lrclibGetThread(QThread):
 
@@ -33,9 +41,13 @@ class lrclibGetThread(QThread):
         self.api = api
         self.idd = idd
 
+
     def run(self):
         ob = self.api.get_lyrics_by_id(self.idd)
+  
+
         lrc = ob.synced_lyrics
+        
         self.lrcGot.emit(lrc)
 
 

--- a/lrcShowX/resultDialog.py
+++ b/lrcShowX/resultDialog.py
@@ -70,7 +70,7 @@ class resultDisplay(QDialog):
 
 class multiLocalLrc(QDialog):
 
-    def __init__(self, parent):
+    def __init__(self):
         super().__init__()
         self.rstl = QListWidget(self)
         self.rstl.setEditTriggers(QAbstractItemView.EditTrigger.NoEditTriggers)

--- a/lrcShowX/tsTool.py
+++ b/lrcShowX/tsTool.py
@@ -9,10 +9,12 @@ class tsTool:
     def __init__(self):
         base_dir = Path(os.path.dirname(os.path.abspath(__file__))).as_posix()
         # print(base_dir)
+        trad = Path(base_dir) / "dict/traditional"
+        simp = Path(base_dir) / "dict/simplified"
         
-        with open(os.path.join(base_dir, "dict/traditional"), 'r', encoding="utf-8") as f:
+        with open(Path(trad).as_posix(), 'r', encoding="utf-8") as f:
             self.tdict = f.read()
-        with open(os.path.join(base_dir, "dict/simplified"), 'r', encoding="utf-8") as f:
+        with open(Path(simp).as_posix(), 'r', encoding="utf-8") as f:
             self.sdict = f.read()
 
     def transfer(self, originalText, symbol = True):  # set True if t2s, else set False

--- a/lrcShowX/tsTool.py
+++ b/lrcShowX/tsTool.py
@@ -1,13 +1,18 @@
 #!/usr/bin/env python
 # -*- coding: utf-8 -*-
 # filename: t2s.py
+import os
+from pathlib import Path
 
 class tsTool:
 
     def __init__(self):
-        with open("lrcShowX/dict/traditional", 'r') as f:
+        base_dir = Path(os.path.dirname(os.path.abspath(__file__))).as_posix()
+        # print(base_dir)
+        
+        with open(os.path.join(base_dir, "dict/traditional"), 'r', encoding="utf-8") as f:
             self.tdict = f.read()
-        with open("lrcShowX/dict/simplified", 'r') as f:
+        with open(os.path.join(base_dir, "dict/simplified"), 'r', encoding="utf-8") as f:
             self.sdict = f.read()
 
     def transfer(self, originalText, symbol = True):  # set True if t2s, else set False

--- a/mainWindow.py
+++ b/mainWindow.py
@@ -8,13 +8,17 @@ from PyQt6.QtWidgets import *
 from PyQt6.QtCore import *
 from PyQt6.QtGui import *
 from PyQt6.QtMultimedia import QMediaPlayer, QAudioOutput, QMediaMetaData, QMediaDevices
-
+from pathlib import Path
 from configuration import configuration
 from windowUI import windowUI
 from engine import engine
 
 from track import track
 
+base_dir = Path(__file__).resolve().parent.as_posix()
+
+# print(base_dir)
+# print(Path(os.path.join(base_dir, "icon/play.png")).as_posix())
 
 
 class mainWindow(windowUI):
@@ -23,7 +27,7 @@ class mainWindow(windowUI):
         super().__init__(devices)
 
         self.setWindowTitle("xting")
-        self.setWindowIcon(QIcon("icon/logo.png"))
+        self.setWindowIcon(QIcon(Path(os.path.join(base_dir, "icon/logo.png")).as_posix()))
         self.timer = QTimer()
 
         self.musicEngine = engine()
@@ -41,7 +45,7 @@ class mainWindow(windowUI):
         self.setShortcuts()
 
         if not self.parameter.currentPlaylistName:
-            path = os.path.join(self.parameter.privatePath, "current.txt")
+            path = Path(os.path.join(self.parameter.privatePath, "current.txt")).as_posix()
             if os.path.exists(path):
                 with open(path, "r") as f:
                     self.playlistTmp = list(map(lambda x: x.strip(), f.readlines()))
@@ -50,12 +54,14 @@ class mainWindow(windowUI):
             else:
                 self.playlistTmp = []
         else:
-            with open(self.parameter.currentPlaylistName, "r") as f:
-                self.playlistTmp = list(map(lambda x: x.strip(), f.readlines()))
-                self.playlistTmp = list(filter(lambda x: os.path.exists(x), self.playlistTmp))
-            self.addToPlaylist(self.playlistTmp)
-
-        self.systemTray = QSystemTrayIcon(QIcon("icon/logo.png"), self)
+            try:
+                with open(self.parameter.currentPlaylistName, "r") as f:
+                    self.playlistTmp = list(map(lambda x: x.strip(), f.readlines()))
+                    self.playlistTmp = list(filter(lambda x: os.path.exists(x), self.playlistTmp))
+                self.addToPlaylist(self.playlistTmp)
+            except FileNotFoundError:
+                open(self.parameter.currentPlaylistName, "x").close()
+        self.systemTray = QSystemTrayIcon(QIcon(Path(os.path.join(base_dir, "icon/logo.png")).as_posix()), self)
         self.systemTray.setContextMenu(self.trayContextMenu)
         self.systemTray.setVisible(self.parameter.trayIcon)
 
@@ -179,7 +185,7 @@ class mainWindow(windowUI):
             self.playorpauseAction.setEnabled(True)
             self.playorpauseAction.setText(self.tr("Play"))
             self.centralWidget.playorpauseButton.setEnabled(True)
-            self.centralWidget.playorpauseButton.setIcon(QIcon("icon/play.png"))
+            self.centralWidget.playorpauseButton.setIcon(QIcon(os.path.join(base_dir, "icon/play.png")))
             self.stopAction.setEnabled(False)
             self.centralWidget.stopButton.setEnabled(False)
             self.previousAction.setEnabled(False)
@@ -195,7 +201,7 @@ class mainWindow(windowUI):
 
         elif status == 1:
             self.playorpauseAction.setText(self.tr("Pause"))
-            self.centralWidget.playorpauseButton.setIcon(QIcon("icon/pause.png"))
+            self.centralWidget.playorpauseButton.setIcon(QIcon(os.path.join(base_dir, "icon/pause.png")))
             self.playorpauseAction.setEnabled(True)
             self.centralWidget.playorpauseButton.setEnabled(True)
             self.stopAction.setEnabled(True)
@@ -207,7 +213,7 @@ class mainWindow(windowUI):
 
         elif status == 2:
             self.playorpauseAction.setText(self.tr("Play"))
-            self.centralWidget.playorpauseButton.setIcon(QIcon("icon/play.png"))
+            self.centralWidget.playorpauseButton.setIcon(QIcon(os.path.join(base_dir, "icon/play.png")))
 
     def addHistoryAction(self):
         if self.addToPlayHistory:
@@ -306,11 +312,11 @@ class mainWindow(windowUI):
     def showTrayInformation(self, v):
         if self.parameter.trayIcon and self.parameter.trayInfo:
             if v == 1:
-                self.systemTray.showMessage(self.tr("Status changed"), f"Now playing: {self.currentTrack.trackTitle} by {self.currentTrack.trackArtist}", QIcon("icon/logo.png"), 6000)
+                self.systemTray.showMessage(self.tr("Status changed"), f"Now playing: {self.currentTrack.trackTitle} by {self.currentTrack.trackArtist}", QIcon(Path(os.path.join(base_dir, "icon/logo.png")).as_posix()), 6000)
             elif v == 2:
-                self.systemTray.showMessage(self.tr("Status changed"), f"Paused: {self.currentTrack.trackTitle} by {self.currentTrack.trackArtist}", QIcon("icon/logo.png"), 6000)
+                self.systemTray.showMessage(self.tr("Status changed"), f"Paused: {self.currentTrack.trackTitle} by {self.currentTrack.trackArtist}", QIcon(Path(os.path.join(base_dir, "icon/logo.png")).as_posix()), 6000)
             else:
-                self.systemTray.showMessage(self.tr("Status changed"), "Stopped", QIcon("icon/logo.png"), 6000)
+                self.systemTray.showMessage(self.tr("Status changed"), "Stopped", QIcon(Path(os.path.join(base_dir, "icon/logo.png")).as_posix()), 6000)
 
     def openFileAction_(self):
         url, fil = QFileDialog.getOpenFileUrl(None, self.tr("choose a music file"), QUrl.fromLocalFile(self.parameter.collectionPath), "music files (*.mp3 *.flac *.ogg *.m4a)")
@@ -427,7 +433,7 @@ class mainWindow(windowUI):
 
     def aboutAppAction_(self):
         b = QMessageBox(self)
-        b.setIconPixmap(QPixmap('icon/logo.png'))
+        b.setIconPixmap(QPixmap(Path(os.path.join(base_dir, "icon/logo.png")).as_posix()))
         b.setWindowTitle(self.tr(f'About {QApplication.arguments()[0]}'))
         b.setText(f'Application: {QApplication.arguments()[0]}\n\nVersion: {QApplication.arguments()[1]}\n\nShort description: xting is a personal local music application, not special. Synced lyrics display is interesting\n\nAuthors: {QApplication.arguments()[2]}\n\nLicense: {QApplication.arguments()[3]}\n\nWebsite: {QApplication.arguments()[4]}')
         b.exec()

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+mutagen==1.47.0
+PyQt6==6.9.0
+PyQt6_sip==13.10.0
+Requests==2.32.3

--- a/track.py
+++ b/track.py
@@ -97,12 +97,12 @@ class track:
             self.trackLength = 0
 
     def loadUnkown(self):
-        self.trackType = "unknow"
+        self.trackType = "unknown"
         self.audio = None
-        self.trackTitle = "unknow"
-        self.trackAlbum = "unknow"
-        self.trackArtist = "unknow"
-        self.trackDate = "unknow"
+        self.trackTitle = "unknown"
+        self.trackAlbum = "unknown"
+        self.trackArtist = "unknown"
+        self.trackDate = "unknown"
         self.trackBitrate = 0
         self.trackSamplerate = 0
         self.trackLength = 0
@@ -113,19 +113,19 @@ class track:
         try:
             self.trackTitle = self.audio["title"][0]
         except:
-            self.trackTitle = "unknow"
+            self.trackTitle = "unknown"
         try:
             self.trackAlbum = self.audio["album"][0]
         except:
-            self.trackAlbum = "unknow"
+            self.trackAlbum = "unknown"
         try:
             self.trackArtist = self.audio["artist"][0]
         except:
-            self.trackArtist = "unknow"
+            self.trackArtist = "unknown"
         try:
             self.trackDate = self.audio["date"][0]
         except:
-            self.trackDate = "unknow"
+            self.trackDate = "unknown"
         try:
             self.trackBitrate = int(self.audio.info.bitrate)
         except:
@@ -143,21 +143,21 @@ class track:
         self.trackType = "mp3"
         self.audio = MP3(self.trackFile)
         try:
-            self.trackTitle = str(self.audio["TIT2"].text[0])
+            self.trackTitle = str(self.audio["TIT2"].text[0])        
         except:
-            self.trackTitle = "unknow"
+            self.trackTitle = "unknown"
         try:
             self.trackAlbum = str(self.audio["TALB"].text[0])
         except:
-            self.trackAlbum = "unknow"
+            self.trackAlbum = "unknown"
         try:
             self.trackArtist = str(self.audio["TPE1"].text[0])
         except:
-            self.trackArtist = "unknow"
+            self.trackArtist = "unknown"
         try:
             self.trackDate = str(self.audio["TDRC"].text[0])
         except:
-            self.trackDate = "unknow"
+            self.trackDate = "unknown"
         try:
             self.trackBitrate = int(self.audio.info.bitrate)
         except:

--- a/windowUI.py
+++ b/windowUI.py
@@ -6,9 +6,12 @@ import os, sys
 from PyQt6.QtWidgets import *
 from PyQt6.QtCore import *
 from PyQt6.QtGui import *
-
+from pathlib import Path
 from dockWidgets import *
 from parameterData import parameterData
+
+base_dir = Path(__file__).resolve().parent.as_posix()
+# print(base_dir)
 
 class windowUI(QMainWindow):
 
@@ -35,23 +38,23 @@ class windowUI(QMainWindow):
 
     def initMenuBar(self):
         self.fileMenu = self.menuBar().addMenu(self.tr("File"))
-        self.openFileAction = QAction(QIcon("icon/open.png"), self.tr("Open..."))
-        self.quitAction = QAction(QIcon("icon/quit.png"), self.tr("Quit"))
+        self.openFileAction = QAction(QIcon(Path(Path(base_dir) / "icon/open.png").as_posix()), self.tr("Open..."))
+        self.quitAction = QAction(QIcon(Path(Path(base_dir) / "icon/quit.png").as_posix()), self.tr("Quit"))
         self.quitAction.setObjectName("quit")
         self.fileMenu.addAction(self.openFileAction)
         self.fileMenu.addSeparator()
         self.fileMenu.addAction(self.quitAction)
 
         self.playbackMenu = self.menuBar().addMenu(self.tr("Playback"))
-        self.previousAction = QAction(QIcon("icon/previous.png"), self.tr("Previous"))
+        self.previousAction = QAction(QIcon(Path(Path(base_dir) / "icon/previous.png").as_posix()), self.tr("Previous"))
         self.previousAction.setEnabled(False)
-        self.playorpauseAction = QAction(QIcon("icon/play.png"), self.tr("Play"))
+        self.playorpauseAction = QAction(QIcon(Path(Path(base_dir) / "icon/play.png").as_posix()), self.tr("Play"))
         self.playorpauseAction.setEnabled(False)
-        self.stopAction = QAction(QIcon("icon/stop.png"), self.tr("Stop"))
+        self.stopAction = QAction(QIcon(Path(Path(base_dir) / "icon/stop.png").as_posix()), self.tr("Stop"))
         self.stopAction.setEnabled(False)
-        self.nextAction = QAction(QIcon("icon/next.png"), self.tr("Next"))
+        self.nextAction = QAction(QIcon(Path(Path(base_dir) / "icon/next.png").as_posix()), self.tr("Next"))
         self.nextAction.setEnabled(False)
-        self.repeatAction = QAction(QIcon("icon/repeat.png"), self.tr("Repeat"))
+        self.repeatAction = QAction(QIcon(Path(Path(base_dir) / "icon/repeat.png").as_posix()), self.tr("Repeat"))
         self.repeatAction.setEnabled(False)
         self.playbackMenu.addAction(self.previousAction)
         self.playbackMenu.addAction(self.playorpauseAction)
@@ -61,11 +64,11 @@ class windowUI(QMainWindow):
 
         self.playlistMenu = self.menuBar().addMenu(self.tr("Playlist"))
         self.loopMenu = self.playlistMenu.addMenu(self.tr("Loop"))
-        self.loopTrackAction = QAction(QIcon("icon/loop track.png"), self.tr("Track"))
+        self.loopTrackAction = QAction(QIcon(Path(Path(base_dir) / "icon/loop track.png").as_posix()), self.tr("Track"))
         self.loopTrackAction.setCheckable(True)
-        self.loopPlaylistAction = QAction(QIcon("icon/loop playlist.png"), self.tr("Playlist"))
+        self.loopPlaylistAction = QAction(QIcon(Path(Path(base_dir) / "icon/loop playlist.png").as_posix()), self.tr("Playlist"))
         self.loopPlaylistAction.setCheckable(True)
-        self.noLoopAction = QAction(QIcon("icon/no loop.png"), self.tr("No loop"))
+        self.noLoopAction = QAction(QIcon(Path(Path(base_dir) / "icon/no loop.png").as_posix()), self.tr("No loop"))
         self.noLoopAction.setCheckable(True)
         self.loopGroup = QActionGroup(self)
         self.loopGroup.addAction(self.loopTrackAction)
@@ -75,11 +78,11 @@ class windowUI(QMainWindow):
         self.loopMenu.addAction(self.loopPlaylistAction)
         self.loopMenu.addAction(self.noLoopAction)
         self.sequenceMenu = self.playlistMenu.addMenu(self.tr("Sequence"))
-        self.sequenceRandomAction = QAction(QIcon("icon/radom.png"), self.tr("Random"))
+        self.sequenceRandomAction = QAction(QIcon(Path(Path(base_dir) / "icon/radom.png").as_posix()), self.tr("Random"))
         self.sequenceRandomAction.setCheckable(True)
-        self.sequenceOrderAction = QAction(QIcon("icon/order.png"), self.tr("Order"))
+        self.sequenceOrderAction = QAction(QIcon(Path(Path(base_dir) / "icon/order.png").as_posix()), self.tr("Order"))
         self.sequenceOrderAction.setCheckable(True)
-        self.sequenceReverseOrderAction = QAction(QIcon("icon/revised.png"), self.tr("Reverse order"))
+        self.sequenceReverseOrderAction = QAction(QIcon(Path(Path(base_dir) / "icon/revised.png").as_posix()), self.tr("Reverse order"))
         self.sequenceReverseOrderAction.setCheckable(True)
         self.sequenceGroup = QActionGroup(self)
         self.sequenceGroup.addAction(self.sequenceOrderAction)
@@ -97,7 +100,7 @@ class windowUI(QMainWindow):
         self.viewMenu.addAction(self.collectionDock.toggleViewAction())
 
         self.audioMenu = self.menuBar().addMenu(self.tr("Audio"))
-        self.deviceMenu = self.audioMenu.addMenu(QIcon("icon/device.png"), self.tr("Device"))
+        self.deviceMenu = self.audioMenu.addMenu(QIcon(Path(Path(base_dir) / "icon/device.png").as_posix()), self.tr("Device"))
         self.deviceGroup = QActionGroup(self)
         n = 0
         for d in self.devices:
@@ -113,12 +116,12 @@ class windowUI(QMainWindow):
         # self.toolsMenu.addAction(self.scanAction)
 
         self.settingMenu = self.menuBar().addMenu(self.tr("Setting"))
-        self.configurationAction = QAction(QIcon("icon/configurate.png"), self.tr("Configurate..."))
+        self.configurationAction = QAction(QIcon(Path(Path(base_dir) / "icon/configurate.png").as_posix()), self.tr("Configurate..."))
         self.settingMenu.addAction(self.configurationAction)
 
         self.helpMenu = self.menuBar().addMenu(self.tr("Help"))
-        self.aboutAppAction = QAction(QIcon("icon/logo.png"), self.tr("About xting..."))
-        self.aboutQtAction = QAction(QIcon("icon/qt.png"), self.tr("About Qt..."))
+        self.aboutAppAction = QAction(QIcon(Path(Path(base_dir) / "icon/logo.png").as_posix()), self.tr("About xting..."))
+        self.aboutQtAction = QAction(QIcon(Path(Path(base_dir) / "icon/qt.png").as_posix()), self.tr("About Qt..."))
         self.helpMenu.addAction(self.aboutAppAction)
         self.helpMenu.addAction(self.aboutQtAction)
 
@@ -171,27 +174,27 @@ class controlWidget(QWidget):
         buttonLayout = QHBoxLayout(None)
         self.previousButton = QPushButton(self)
         self.previousButton.setMinimumSize(50, 50)
-        self.previousButton.setIcon(QIcon("icon/previous.png"))
+        self.previousButton.setIcon(QIcon(Path(Path(base_dir) / "icon/previous.png").as_posix()))
         self.previousButton.setIconSize(QSize(40, 40))
         self.previousButton.setEnabled(False)
         self.playorpauseButton = QPushButton(self)
         self.playorpauseButton.setMinimumSize(50, 50)
-        self.playorpauseButton.setIcon(QIcon("icon/play.png"))
+        self.playorpauseButton.setIcon(QIcon(Path(Path(base_dir) / "icon/play.png").as_posix()))
         self.playorpauseButton.setIconSize(QSize(40, 40))
         self.playorpauseButton.setEnabled(False)
         self.stopButton = QPushButton(self)
         self.stopButton.setMinimumSize(50, 50)
-        self.stopButton.setIcon(QIcon("icon/stop.png"))
+        self.stopButton.setIcon(QIcon(Path(Path(base_dir) / "icon/stop.png").as_posix()))
         self.stopButton.setIconSize(QSize(40, 40))
         self.stopButton.setEnabled(False)
         self.nextButton = QPushButton(self)
         self.nextButton.setMinimumSize(50, 50)
-        self.nextButton.setIcon(QIcon("icon/next.png"))
+        self.nextButton.setIcon(QIcon(Path(Path(base_dir) / "icon/next.png").as_posix()))
         self.nextButton.setIconSize(QSize(40, 40))
         self.nextButton.setEnabled(False)
         self.repeatButton = QPushButton(self)
         self.repeatButton.setMinimumSize(50, 50)
-        self.repeatButton.setIcon(QIcon("icon/repeat.png"))
+        self.repeatButton.setIcon(QIcon(Path(Path(base_dir) / "icon/repeat.png").as_posix()))
         self.repeatButton.setIconSize(QSize(40, 40))
         self.repeatButton.setEnabled(False)
         self.volumeSlider = QSlider(self)

--- a/xting.py
+++ b/xting.py
@@ -7,7 +7,7 @@ from PyQt6.QtMultimedia import QMediaDevices
 from PyQt6.QtCore import QLocale, QTranslator
 from mainWindow import mainWindow
 import sys, os
-
+from pathlib import Path
 
 
 if __name__ == "__main__":
@@ -19,11 +19,13 @@ if __name__ == "__main__":
     __website__ = "https://github.com/sanfanling/xting"
     __supportedAudioformat__ = ["mp3", "flac", "ogg"]
 
-    appdir = os.path.join(os.path.expanduser("~"), ".xting")
+    
+
+    appdir = Path(os.path.join(os.path.expanduser("~"), ".xting")).as_posix()
     if not os.path.isdir(appdir):
         os.mkdir(appdir)
-    if not os.path.isdir(os.path.join(appdir, "lrc")):
-        os.mkdir(os.path.join(appdir, "lrc"))
+    if not os.path.isdir(Path(os.path.join(appdir, "lrc")).as_posix()):
+        os.mkdir(Path(os.path.join(appdir, "lrc")).as_posix())
 
     args = [__application__, __version__, __author__, __license__, __website__, __supportedAudioformat__]
     app = QApplication(args)

--- a/xting.py
+++ b/xting.py
@@ -19,7 +19,7 @@ if __name__ == "__main__":
     __website__ = "https://github.com/sanfanling/xting"
     __supportedAudioformat__ = ["mp3", "flac", "ogg"]
 
-    
+    base_dir = Path(__file__).resolve().parent.as_posix()
 
     appdir = Path(os.path.join(os.path.expanduser("~"), ".xting")).as_posix()
     if not os.path.isdir(appdir):
@@ -32,7 +32,8 @@ if __name__ == "__main__":
 
     locale = QLocale.system().name()
     translator = QTranslator()
-    if translator.load(f'translations/{locale}/xting.qm'):
+    translator_Folder = Path(base_dir) / f'translations/{locale}/xting.qm'
+    if translator.load(Path(translator_Folder).as_posix()):
         app.installTranslator(translator)
     # else:
     #     print(f'No translation file found for {locale}')


### PR DESCRIPTION
- I normalized the path of files to posix to not have to deal with windows paths

- Added a `try except FileNotFoundError` on the `mainWindowUI.py` on line 57 that caused crashes when the file doesn't exist yet
- Added absolute paths relative to the xting.py location (so now you can run the file `xting.py` outside of the main directory)
- Fixed the bug that was caused by opening the file `dict/traditional` and `dict/simplified` on lines 13 and 15 of the file `tsTool.py` by opening them in utf-8 encoding on Windows 10

- Tested on Windows 10 and proven to work